### PR TITLE
Fix warnings

### DIFF
--- a/src/abstract_hardware_model.h
+++ b/src/abstract_hardware_model.h
@@ -442,19 +442,25 @@ protected:
     class gpgpu_sim * m_gpu;
 };
 
-#define GLOBAL_HEAP_START 0xC0000000
-   // start allocating from this address (lower values used for allocating globals in .ptx file)
-#define SHARED_MEM_SIZE_MAX (96*1024)
-#define LOCAL_MEM_SIZE_MAX (16*1024)
-#define MAX_STREAMING_MULTIPROCESSORS 80   //scale it to Volta
-#define MAX_THREAD_PER_SM 2048
-#define MAX_WARP_PER_SM 64
-#define TOTAL_LOCAL_MEM_PER_SM (MAX_THREAD_PER_SM*LOCAL_MEM_SIZE_MAX)
-#define TOTAL_SHARED_MEM (MAX_STREAMING_MULTIPROCESSORS*SHARED_MEM_SIZE_MAX)
-#define TOTAL_LOCAL_MEM (MAX_STREAMING_MULTIPROCESSORS*MAX_THREAD_PER_SM*LOCAL_MEM_SIZE_MAX)
-#define SHARED_GENERIC_START (GLOBAL_HEAP_START-TOTAL_SHARED_MEM)
-#define LOCAL_GENERIC_START (SHARED_GENERIC_START-TOTAL_LOCAL_MEM)
-#define STATIC_ALLOC_LIMIT (GLOBAL_HEAP_START - (TOTAL_LOCAL_MEM+TOTAL_SHARED_MEM))
+// Let's just upgrade to C++11 so we can use constexpr here...
+// start allocating from this address (lower values used for allocating globals in .ptx file)
+const unsigned long long GLOBAL_HEAP_START = 0xC0000000;
+// Volta max shmem size is 96kB
+const unsigned long long SHARED_MEM_SIZE_MAX = 96 * (1 << 10);
+// Volta max local mem is 16kB
+const unsigned long long LOCAL_MEM_SIZE_MAX = 1 << 14;
+// Volta Titan V has 80 SMs
+const unsigned MAX_STREAMING_MULTIPROCESSORS = 80;
+// Max 2048 threads / SM
+const unsigned MAX_THREAD_PER_SM = 1 << 11;
+// MAX 64 warps / SM
+const unsigned MAX_WARP_PER_SM = 1 << 6;
+const unsigned long long TOTAL_LOCAL_MEM_PER_SM = MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
+const unsigned long long TOTAL_SHARED_MEM = MAX_STREAMING_MULTIPROCESSORS * SHARED_MEM_SIZE_MAX;
+const unsigned long long TOTAL_LOCAL_MEM = MAX_STREAMING_MULTIPROCESSORS * MAX_THREAD_PER_SM * LOCAL_MEM_SIZE_MAX;
+const unsigned long long SHARED_GENERIC_START = GLOBAL_HEAP_START - TOTAL_SHARED_MEM;
+const unsigned long long LOCAL_GENERIC_START = SHARED_GENERIC_START - TOTAL_LOCAL_MEM;
+const unsigned long long STATIC_ALLOC_LIMIT = GLOBAL_HEAP_START - (TOTAL_LOCAL_MEM + TOTAL_SHARED_MEM);
 
 #if !defined(__CUDA_RUNTIME_API_H__)
 

--- a/src/cuda-sim/cuda-sim.cc
+++ b/src/cuda-sim/cuda-sim.cc
@@ -1309,7 +1309,7 @@ void function_info::ptx_jit_config(std::map<unsigned long long, size_t> mallocPt
     char buff[1024];
     std::string filename_c(filename+"_c");
     snprintf(buff,1024,"c++filt %s > %s", get_name().c_str(), filename_c.c_str());
-    system(buff);
+    assert(system(buff) != NULL);
     FILE *fp = fopen(filename_c.c_str(), "r");
     fgets(buff, 1024, fp);
     fclose(fp);
@@ -1432,13 +1432,13 @@ void function_info::ptx_jit_config(std::map<unsigned long long, size_t> mallocPt
     fout = fopen(ptx_config_fn.c_str(), "a");
     assert(fout!=NULL);
     for (unsigned i = 0; i<line_number; i++){
-        fgets(buff, 1024, fin);
+        assert(fgets(buff, 1024, fin) != NULL);
         assert(!feof(fin));
     }
     fprintf(fout, "\n\n");
     do{
         fprintf(fout, "%s", buff);
-        fgets(buff, 1024, fin);
+        assert(fgets(buff, 1024, fin) != NULL);
         if(feof(fin)){
             break;
         }

--- a/src/cuda-sim/half.h
+++ b/src/cuda-sim/half.h
@@ -642,10 +642,10 @@ namespace half_float
 			if(exp > 16)
 			{
 				if(R == std::round_toward_infinity)
-					return hbits | 0x7C00 - (hbits>>15);
+					return hbits | (0x7C00 - (hbits>>15));
 				else if(R == std::round_toward_neg_infinity)
-					return hbits | 0x7BFF + (hbits>>15);
-				return hbits | 0x7BFF + (R!=std::round_toward_zero);
+					return hbits | (0x7BFF + (hbits>>15));
+				return hbits | (0x7BFF + (R!=std::round_toward_zero));
 			}
 			if(exp < -13)
 				value = std::ldexp(value, 24);

--- a/src/cuda-sim/instructions.cc
+++ b/src/cuda-sim/instructions.cc
@@ -224,7 +224,6 @@ void ptx_thread_info::resume_reg_thread(char * fname, symbol_table * symtab)
       {
           symbol *reg;
           char * pch;
-          unsigned size;
           pch = strtok (line," ");
           char * name =pch;
           reg= symtab->lookup(name);
@@ -233,9 +232,6 @@ void ptx_thread_info::resume_reg_thread(char * fname, symbol_table * symtab)
           data = atoi(pch);
           pch = strtok (NULL," ");
           pch = strtok (NULL," ");
-          size = atoi(pch);
-
-
           m_regs.back()[reg] = data;
       }
       fclose ( fp2 );
@@ -3080,7 +3076,7 @@ void mma_st_impl( const ptx_instruction *pI, core_t *core, warp_inst_t &inst )
    size_t size;
    unsigned smid;
    int t;
-   int thrd, odd, inx, k;
+   int thrd, k;
    ptx_thread_info *thread;
    
    const operand_info &src  = pI->operand_lookup(1);
@@ -3100,8 +3096,6 @@ void mma_st_impl( const ptx_instruction *pI, core_t *core, warp_inst_t &inst )
    _memory_op_t insn_memory_op = pI->has_memory_read() ? memory_load : memory_store;
    for (thrd=0; thrd < core->get_warp_size(); thrd++) {
 	thread = core->get_thread_info()[tid+thrd];
-	odd= thrd % 2;
-	inx= thrd / 2;
     ptx_reg_t addr_reg = thread->get_operand_value(src1, src, type, thread, 1);
    	ptx_reg_t src2_data = thread->get_operand_value(src2, src, type, thread, 1);
 	const operand_info &src_a=  pI->operand_lookup(1);

--- a/src/cuda-sim/ptx_ir.cc
+++ b/src/cuda-sim/ptx_ir.cc
@@ -1415,7 +1415,7 @@ unsigned function_info::print_insn( unsigned pc, FILE * fp ) const
    snprintf(command,1024,"c++filt -p %s",m_name.c_str());
    FILE *p = popen(command,"r");
    buffer[0]=0;
-   fgets(buffer, 1023, p);
+   assert(fgets(buffer, 1023, p) != NULL);
    // Remove trailing "\n" in buffer
    char *c;
    if ((c=strchr(buffer, '\n')) != NULL) *c = '\0';

--- a/src/cuda-sim/ptx_loader.cc
+++ b/src/cuda-sim/ptx_loader.cc
@@ -214,7 +214,8 @@ void fix_duplicate_errors(char fname2[1024]) {
 	long filesize = ftell(ptxsource);
 	rewind(ptxsource);
 	char *ptxdata = (char*)malloc((filesize+1)*sizeof(char));
-	fread(ptxdata, filesize, 1, ptxsource);
+    // Fail if we do not read the file
+	assert(fread(ptxdata, filesize, 1, ptxsource) == 1);
 	fclose(ptxsource);
 
 	FILE *ptxdest = fopen(fname2,"w");


### PR DESCRIPTION
Fixed some more some more warnings. Getting rid of some preprocessor macros for more type safety (would be nice to move to C++11 and use constexpr, or completely re-structure the way the address start calculations are made).