### PR TITLE
Add a new config option to cap the max number of completed CTAs

### DIFF
--- a/src/gpgpu-sim/gpu-sim.cc
+++ b/src/gpgpu-sim/gpu-sim.cc
@@ -528,6 +528,9 @@ void gpgpu_sim_config::reg_options(option_parser_t opp) {
                          "terminates gpu simulation early (0 = no limit)", "0");
   option_parser_register(opp, "-gpgpu_max_cta", OPT_INT32, &gpu_max_cta_opt,
                          "terminates gpu simulation early (0 = no limit)", "0");
+  option_parser_register(opp, "-gpgpu_max_completed_cta", OPT_INT32,
+                         &gpu_max_completed_cta_opt,
+                         "terminates gpu simulation early (0 = no limit)", "0");
   option_parser_register(
       opp, "-gpgpu_runtime_stat", OPT_CSTR, &gpgpu_runtime_stat,
       "display runtime statistics such as dram utilization {<freq>:<flag>}",
@@ -785,6 +788,7 @@ gpgpu_sim::gpgpu_sim(const gpgpu_sim_config &config, gpgpu_context *ctx)
   gpu_sim_insn = 0;
   gpu_tot_sim_insn = 0;
   gpu_tot_issued_cta = 0;
+  gpu_completed_cta = 0;
   m_total_cta_launched = 0;
   gpu_deadlock = false;
 
@@ -923,6 +927,9 @@ bool gpgpu_sim::active() {
   if (m_config.gpu_max_cta_opt &&
       (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt))
     return false;
+  if (m_config.gpu_max_completed_cta_opt &&
+      (gpu_completed_cta >= m_config.gpu_max_completed_cta_opt))
+    return false;
   if (m_config.gpu_deadlock_detect && gpu_deadlock) return false;
   for (unsigned i = 0; i < m_shader_config->n_simt_clusters; i++)
     if (m_cluster[i]->get_not_completed() > 0) return true;
@@ -941,6 +948,7 @@ void gpgpu_sim::init() {
   gpu_sim_insn = 0;
   last_gpu_sim_insn = 0;
   m_total_cta_launched = 0;
+  gpu_completed_cta = 0;
   partiton_reqs_in_parallel = 0;
   partiton_replys_in_parallel = 0;
   partiton_reqs_in_parallel_util = 0;
@@ -999,6 +1007,7 @@ void gpgpu_sim::update_stats() {
   gpu_sim_cycle_parition_util = 0;
   gpu_sim_insn = 0;
   m_total_cta_launched = 0;
+  gpu_completed_cta = 0;
   gpu_occupancy = occupancy_stats();
 }
 

--- a/src/gpgpu-sim/gpu-sim.h
+++ b/src/gpgpu-sim/gpu-sim.h
@@ -392,6 +392,7 @@ class gpgpu_sim_config : public power_config,
   unsigned long long gpu_max_cycle_opt;
   unsigned long long gpu_max_insn_opt;
   unsigned gpu_max_cta_opt;
+  unsigned gpu_max_completed_cta_opt;
   char *gpgpu_runtime_stat;
   bool gpgpu_flush_l1_cache;
   bool gpgpu_flush_l2_cache;
@@ -495,12 +496,14 @@ class gpgpu_sim : public gpgpu_t {
            (m_config.gpu_max_insn_opt &&
             (gpu_tot_sim_insn + gpu_sim_insn) >= m_config.gpu_max_insn_opt) ||
            (m_config.gpu_max_cta_opt &&
-            (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt));
+            (gpu_tot_issued_cta >= m_config.gpu_max_cta_opt)) ||
+           (m_config.gpu_max_completed_cta_opt &&
+            (gpu_completed_cta >= m_config.gpu_max_completed_cta_opt));
   }
   void print_stats();
   void update_stats();
   void deadlock_check();
-
+  void inc_completed_cta() { gpu_completed_cta++; }
   void get_pdom_stack_top_info(unsigned sid, unsigned tid, unsigned *pc,
                                unsigned *rpc);
 
@@ -588,6 +591,7 @@ class gpgpu_sim : public gpgpu_t {
   // count.
   unsigned long long m_total_cta_launched;
   unsigned long long gpu_tot_issued_cta;
+  unsigned gpu_completed_cta;
 
   unsigned m_last_cluster_issue;
   float *average_pipeline_duty_cycle;

--- a/src/gpgpu-sim/shader.cc
+++ b/src/gpgpu-sim/shader.cc
@@ -2511,6 +2511,8 @@ void shader_core_ctx::register_cta_thread_exit(unsigned cta_num,
   assert(m_cta_status[cta_num] > 0);
   m_cta_status[cta_num]--;
   if (!m_cta_status[cta_num]) {
+    // Increment the completed CTAs
+    m_gpu->inc_completed_cta();
     m_n_active_cta--;
     m_barriers.deallocate_barrier(cta_num);
     shader_CTA_count_unlog(m_sid, 1);


### PR DESCRIPTION
Caps the maximum completed CTAs completed by a kernel. Similar to the other "gpgpu_max..." arguments, this will kill the program.