### PR TITLE
Test support for old GCC version w/ C++0x flag

### DIFF
--- a/libcuda/Makefile
+++ b/libcuda/Makefile
@@ -88,7 +88,7 @@ PROG     =cuda
 CXX_SRCS =  cuda_runtime_api.cc
 LEX_SRCS = cuobjdump.l
 YACC_SRCS = cuobjdump.y
-CXXFLAGS += --std=c++11 -DCUDART_VERSION=$(CUDART_VERSION)
+CXXFLAGS += --std=c++0x -DCUDART_VERSION=$(CUDART_VERSION)
 LEX			= flex
 LEXFLAGS	= -B 
 YACC		= bison

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,7 +34,7 @@ TRACE?=1
 
 include ../version_detection.mk
 
-CXXFLAGS = --std=c++11 -Wall -DDEBUG
+CXXFLAGS = --std=c++0x -Wall -DDEBUG
 CXXFLAGS += -DCUDART_VERSION=$(CUDART_VERSION)
 
 ifeq ($(GNUC_CPP0X), 1)

--- a/src/cuda-sim/Makefile
+++ b/src/cuda-sim/Makefile
@@ -42,7 +42,7 @@ include ../../version_detection.mk
 
 OUTPUT_DIR=$(SIM_OBJ_FILES_DIR)/cuda-sim
 
-OPT	:= --std=c++11 -O3 -g3 -Wall -Wno-unused-function -Wno-sign-compare
+OPT	:= --std=c++0x -O3 -g3 -Wall -Wno-unused-function -Wno-sign-compare
 ifeq ($(DEBUG),1)
 	OPT := -g3 -Wall  -Wno-unused-function -Wno-sign-compare
 endif

--- a/src/gpgpu-sim/Makefile
+++ b/src/gpgpu-sim/Makefile
@@ -53,7 +53,7 @@ else
 	CXXFLAGS += 
 endif
 
-CXXFLAGS += --std=c++11 -I$(CUDA_INSTALL_PATH)/include
+CXXFLAGS += --std=c++0x -I$(CUDA_INSTALL_PATH)/include
 
 POWER_FLAGS=
 ifneq ($(GPGPUSIM_POWER_MODEL),)


### PR DESCRIPTION
Regressions seem to fail because the older version of GCC does not support `--std=c++11`. This tests regression with the `--std=c++0x` flag that should enable experimental support for C++11 in older versions of GCC.